### PR TITLE
Migrate API: .NET 6 -> .NET 9

### DIFF
--- a/api/Lookup.cs
+++ b/api/Lookup.cs
@@ -54,7 +54,6 @@ namespace WebSearch.Function
             };
 
             var response = req.CreateResponse(HttpStatusCode.Found);
-            response.Headers.Add("Content-Type", "application/json; charset=utf-8");
 
             // Serialize data
             var serializer = new JsonObjectSerializer(

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 
 var host = new HostBuilder()
-    .ConfigureFunctionsWorkerDefaults()
+    .ConfigureFunctionsWebApplication()
     .Build();
 
 host.Run();

--- a/api/azure-search-function.csproj
+++ b/api/azure-search-function.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -8,10 +8,15 @@
     <RootNamespace>dotnet_fn</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Azure.Search.Documents" Version="11.4.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.8.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.7.0" />
+    <!-- Application Insights isn't enabled by default. See https://aka.ms/AAt8mw4. -->
+    <!-- <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" /> -->
+    <!-- <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" /> -->
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/api/host.json
+++ b/api/host.json
@@ -5,7 +5,8 @@
             "samplingSettings": {
                 "isEnabled": true,
                 "excludedTypes": "Request"
-            }
+            },
+            "enableLiveMetricsFilters": true
         }
     }
 }


### PR DESCRIPTION
Move the API to .NET 9

- This is a minimal move to run the API. No v9 idiomatic changes are made but should be scheduled for future work. 
- Use the HTTP requests in /api/http to test the API after `dotnet run`.